### PR TITLE
Fix palette selection logic and add tests

### DIFF
--- a/tackle/tests/test_utils.py
+++ b/tackle/tests/test_utils.py
@@ -1,0 +1,42 @@
+import matplotlib as mpl
+import pandas as pd
+import seaborn as sb
+
+from tackle.utils import get_default_color_mapping
+
+
+def test_get_default_color_mapping_integer_like_series_uses_light_palette():
+    series = pd.Series(["1", "2", "3"])
+
+    mapping = get_default_color_mapping(series)
+
+    numeric_series = pd.to_numeric(series, errors="coerce")
+    unique_values = sorted(numeric_series.unique())
+    expected_colors = [
+        mpl.colors.rgb2hex(color)
+        for color in sb.color_palette(
+            palette="light:#4133", n_colors=len(unique_values)
+        )
+    ]
+    expected_mapping = {
+        str(value): color for value, color in zip(unique_values, expected_colors)
+    }
+
+    assert mapping == expected_mapping
+
+
+def test_get_default_color_mapping_non_integer_series_uses_bright_palette():
+    series = pd.Series(["apple", "banana", "cherry"])
+
+    mapping = get_default_color_mapping(series)
+
+    unique_values = sorted(series.unique())
+    expected_colors = [
+        mpl.colors.rgb2hex(color)
+        for color in sb.color_palette(palette="bright", n_colors=len(unique_values))
+    ]
+    expected_mapping = {
+        str(value): color for value, color in zip(unique_values, expected_colors)
+    }
+
+    assert mapping == expected_mapping

--- a/tackle/utils.py
+++ b/tackle/utils.py
@@ -58,12 +58,11 @@ def get_default_color_mapping(s: pd.Series) -> dict:
         return
     palette = "bright"
     s_as_numeric = pd.to_numeric(s, errors="coerce")
-    if (
-        s_as_numeric.sum()
-        > 0 & s_as_numeric.nunique()
-        < 11 & s_as_numeric.isna().sum()
-        == 0
-    ):  # integer
+    has_positive_sum = s_as_numeric.sum() > 0
+    limited_unique_values = s_as_numeric.nunique() < 11
+    has_no_missing = s_as_numeric.isna().sum() == 0
+
+    if has_positive_sum and limited_unique_values and has_no_missing:  # integer
         s = s_as_numeric
         palette = "light:#4133"
 


### PR DESCRIPTION
## Summary
- replace the integer detection in `get_default_color_mapping` with explicit boolean checks
- add tests that cover integer-like and non-integer series to validate palette selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8e8c122d08332804699807cb52e23