### PR TITLE
Fix clean_categorical to iterate over all categorical columns

### DIFF
--- a/tackle/tests/test_clean_categorical.py
+++ b/tackle/tests/test_clean_categorical.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from tackle.utils import clean_categorical
+
+
+def test_clean_categorical_multiple_columns():
+    df = pd.DataFrame(
+        {
+            "first": pd.Series([1, 2, 1], dtype="category"),
+            "second": pd.Series([3, 4, 3], dtype="category"),
+        }
+    )
+
+    # Sanity check: categories start as non-strings.
+    assert any(not isinstance(cat, str) for cat in df["first"].cat.categories)
+    assert any(not isinstance(cat, str) for cat in df["second"].cat.categories)
+
+    cleaned = clean_categorical(df)
+
+    for column in ("first", "second"):
+        assert all(isinstance(cat, str) for cat in cleaned[column].cat.categories)

--- a/tackle/utils.py
+++ b/tackle/utils.py
@@ -31,14 +31,13 @@ import click
 
 def clean_categorical(col_data):
     for col in col_data:
-        if isinstance(col_data[col], pd.CategoricalDtype):
+        series = col_data[col]
+        if isinstance(series.dtype, pd.CategoricalDtype):
             # check to make sure categories are strings
-            cats = col_data[col].cat.categories
+            cats = series.cat.categories
             if not (all(isinstance(x, str) for x in cats)):
-                newcats = [str(x) for x in cats]  # do not need?
-                newvalues = [str(x) for x in col_data[col]]
-                col_data[col] = pd.CategoricalDtype(newvalues)
-        return col_data
+                col_data[col] = series.cat.rename_categories(lambda x: str(x))
+    return col_data
 
 
 RESERVED_COLORS = {


### PR DESCRIPTION
## Summary
- ensure `clean_categorical` iterates over every categorical column and normalises category labels to strings
- add a regression test covering multiple categorical columns

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8e8e3fc9483329086f09d7a1bf2ae